### PR TITLE
fix posgreSQL ssl for heroku and local database

### DIFF
--- a/backend/features/database/connection.js
+++ b/backend/features/database/connection.js
@@ -1,4 +1,4 @@
 var pgp = require("pg-promise")();
-var dbConnectionString = process.env.DATABASE_URL + '?ssl=true';
+var dbConnectionString = process.env.EM_PG_CONN;
 var db = pgp(dbConnectionString);
 module.exports = db;


### PR DESCRIPTION
add EM_PG_CONN environment variable as a connection string. this allows to use both local and heroku databases without any code changes.
It is safe to merge that because environment variable is set in heroku config